### PR TITLE
Fix permissions on sites/default - matches permissions set on pantheon

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -150,9 +150,8 @@ else
 fi
 
 SETTINGS_SITE="$DESTINATION/profiles/$PROJECT/scripts/settings/site.settings.php"
-chmod 775 $DESTINATION/sites/default
+chmod 755 $DESTINATION/sites/default
 cp $SETTINGS_SITE $DESTINATION/sites/default/site.settings.php
-chmod 555 $DESTINATION/sites/default
 echo "Copied site.settings.php into place."
 
 echo "Build script complete."


### PR DESCRIPTION
Fixes `error: unable to create file sites/default/settings.php (Permission denied)` when pushing changes to pantheon using `deploy.sh`